### PR TITLE
Add configurable small pages option

### DIFF
--- a/src/serverMain/kotlin/com/studo/campusqr/database/InitialSetup.kt
+++ b/src/serverMain/kotlin/com/studo/campusqr/database/InitialSetup.kt
@@ -90,6 +90,8 @@ suspend fun initialDatabaseSetup() {
       insert("checkInIpAddressHeader", "") // Set to "X-Forwarded-For" (or custom) if IP address should be stored on checkIn
 
       insert("authSharedSecret", "") // Auth via X-Authorization header. If empty, no shared secret access is possible.
+
+      insert("multiSeatLocationsUseSmallCheckinPages", 0) // If 1, the printable QR codes use A5 instead of A4 format
     }
 
     // Create root user

--- a/src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt
+++ b/src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt
@@ -36,7 +36,7 @@ suspend fun AuthenticatedApplicationCall.viewSingleQrCode() {
           ).get(this@viewSingleQrCode)
         }
       } else {
-        renderPrintPage(language, smallPages = location.seatCount != null) {
+        renderPrintPage(language) {
           renderLocation(location, configs)
         }
       }
@@ -58,14 +58,15 @@ suspend fun AuthenticatedApplicationCall.viewCheckoutCode() {
     }
 
     body {
-      renderPrintPage(language, smallPages = false) {
+      renderPrintPage(language) {
         renderQrCodePage(
           "Check Out",
           "checkout",
           configs,
           subtext1 = configs.getValue("scanCheckoutSubtext1"),
           subtext2 = configs.getValue("scanCheckoutSubtext1"),
-          subtitle = ""
+          subtitle = "",
+          smallPage = false
         )
       }
     }
@@ -96,7 +97,7 @@ suspend fun AuthenticatedApplicationCall.viewAllQrCodes() {
           ).get(this@viewAllQrCodes)
         }
       } else {
-        renderPrintPage(language, smallPages = false) {
+        renderPrintPage(language) {
           for (location in locations) {
             renderLocation(location, configs)
           }
@@ -106,12 +107,7 @@ suspend fun AuthenticatedApplicationCall.viewAllQrCodes() {
   }
 }
 
-fun FlowContent.renderPrintPage(language: String, smallPages: Boolean, block: FlowContent.() -> Unit) {
-  if (smallPages && getConfig("multiSeatLocationsUseSmallCheckinPages")) {
-    style {
-      +"@page { size: A4 landscape; }"
-    }
-  }
+fun FlowContent.renderPrintPage(language: String, block: FlowContent.() -> Unit) {
   noScript {
     +"You need to enable JavaScript to run this app."
   }
@@ -160,12 +156,12 @@ fun FlowContent.renderLocation(location: ClientLocation, configs: Map<String, St
     } else {
       for (seat in 1..location.seatCount) {
         val paddedSeat = seat.toString().padStart(location.seatCount.toString().length, '0')
-        renderQrCodePage("${location.name} #$paddedSeat", "${location.id}-$seat", configs)
+        renderQrCodePage("${location.name} #$paddedSeat", "${location.id}-$seat", configs, smallPage = false)
         div("break") {}
       }
     }
   } else {
-    renderQrCodePage(location.name, location.id, configs)
+    renderQrCodePage(location.name, location.id, configs, smallPage = false)
   }
 }
 
@@ -176,7 +172,7 @@ fun FlowContent.renderQrCodePage(
   subtext1: String = configs.getValue("scanSubtext1"),
   subtext2: String = configs.getValue("scanSubtext2"),
   subtitle: String = "Check In",
-  smallPage: Boolean = false, // True if there are two Din A5 pages side by side on one Din A4 sheet
+  smallPage: Boolean, // True if there are two Din A5 pages side by side on one Din A4 sheet
 ) {
   val htmlResourcePath = if (smallPage) "viewQR/qrcode_print_template_a5.html" else "viewQR/qrcode_print_template_a4.html"
   val htmlString = (HtmlTemplateCache[htmlResourcePath] ?: "template missing")

--- a/src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt
+++ b/src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt
@@ -146,7 +146,7 @@ fun FlowContent.renderLocation(location: ClientLocation, configs: Map<String, St
         div("small-pages-container") { // Crops the inner container
           div("small-pages-scaling-container") { // Scales content to 0.5
             // Render the two pages as if they were full-size
-            for (seat in listOf(skippedSeat, skippedSeat + 1)) {
+            for (seat in listOfNotNull(skippedSeat, if (skippedSeat < location.seatCount) skippedSeat + 1 else null)) {
               val paddedSeat = seat.toString().padStart(location.seatCount.toString().length, '0')
               renderQrCodePage("${location.name} #$paddedSeat", "${location.id}-$seat", configs, smallPage = true)
             }

--- a/src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt
+++ b/src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt
@@ -178,25 +178,20 @@ fun FlowContent.renderQrCodePage(
   subtitle: String = "Check In",
   smallPage: Boolean = false, // True if there are two Din A5 pages side by side on one Din A4 sheet
 ) {
-  div("page") {
-    div("header") {
-      h1 {
-        +name
-      }
-      p {
-        +subtitle
-      }
-    }
-    div("qrcode") {
-      this.id = id
-    }
-    div("footer") {
-      p {
-        +subtext1
-      }
-      p {
-        +subtext2
-      }
-    }
+  val htmlResourcePath = if (smallPage) "viewQR/qrcode_print_template_a5.html" else "viewQR/qrcode_print_template_a4.html"
+  val htmlString = (HtmlTemplateCache[htmlResourcePath] ?: "template missing")
+      .replace("%%NAME%%", name)
+      .replace("%%ID%%", id)
+      .replace("%%SUBTEXT_1%%", subtext1)
+      .replace("%%SUBTEXT_2%%", subtext2)
+      .replace("%%SUBTITLE%%", subtitle)
+
+  div { unsafe { raw(htmlString) } }
+}
+
+object HtmlTemplateCache {
+  private val cacheMap: MutableMap<String, String> = mutableMapOf() // Resource path to raw resource string
+  operator fun get(path: String): String? {
+    return cacheMap[path] ?: this::class.java.classLoader.getResource(path)?.readText()?.also { cacheMap[path] = it }
   }
 }

--- a/src/serverMain/resources/viewQR/qrcode_print_template_a4.html
+++ b/src/serverMain/resources/viewQR/qrcode_print_template_a4.html
@@ -1,0 +1,19 @@
+<!--
+You can reference resources such as javascript or css by placing the files in the same directory as this one and using the following path:
+"/static/viewQR/your_css_file.css"
+
+Available substitutions are: NAME, SUBTITLE, SUBTEXT_1, SUBTEXT_2.
+To add more, edit `FlowContent.renderQrCodePage()` in  src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt or contact us.
+-->
+
+<div class="page">
+  <div class="header">
+    <h1>%%NAME%%</h1>
+    <p>%%SUBTITLE%%</p>
+  </div>
+  <div class="qrcode" id="%%ID%%"></div>
+  <div class="footer">
+    <p>%%SUBTEXT_1%%</p>
+    <p>%%SUBTEXT_2%%</p>
+  </div>
+</div>

--- a/src/serverMain/resources/viewQR/qrcode_print_template_a5.html
+++ b/src/serverMain/resources/viewQR/qrcode_print_template_a5.html
@@ -1,0 +1,21 @@
+<!--
+This printing template will only be used if the multiSeatLocationsUseSmallCheckinPages config is set to true and the room in question as multiple seats.
+
+You can reference resources such as javascript or css by placing the files in the same directory as this one and using the following path:
+"/static/viewQR/your_css_file.css"
+
+Available substitutions are: NAME, SUBTITLE, SUBTEXT_1, SUBTEXT_2.
+To add more, edit `FlowContent.renderQrCodePage()` in  src/serverMain/kotlin/com/studo/campusqr/endpoints/QrCodes.kt or contact us.
+-->
+
+<div class="page">
+  <div class="header">
+    <h1>%%NAME%%</h1>
+    <p>%%SUBTITLE%%</p>
+  </div>
+  <div class="qrcode" id="%%ID%%"></div>
+  <div class="footer">
+    <p>%%SUBTEXT_1%%</p>
+    <p>%%SUBTEXT_2%%</p>
+  </div>
+</div>

--- a/src/serverMain/resources/viewQR/styles.css
+++ b/src/serverMain/resources/viewQR/styles.css
@@ -55,7 +55,7 @@ header > h2 {
 
 .small-pages-scaling-container > .page:first-child {
   /* Separates left & right page and helps centering the cut */
-  border-right: 1px solid #2f2f2f;
+  border-right: 1px solid #b3b3b3;
 }
 
 div.break {

--- a/src/serverMain/resources/viewQR/styles.css
+++ b/src/serverMain/resources/viewQR/styles.css
@@ -28,11 +28,12 @@ header > h2 {
 }
 
 .small-pages-container {
-  /* height must be 1mm less than A4 because of rounding errors that would otherwise leave empty pages */
-  height: 209mm;
-  width: 297mm;
-  overflow: hidden;
+  /* width must be 1mm less than A4 because of rounding errors that would otherwise leave empty pages */
+  height: 297mm;
+  width: 209mm;
   page-break-after: always;
+  transform: translateX(209mm) rotate(90deg);
+  transform-origin: top left;
 }
 
 .small-pages-scaling-container {
@@ -53,7 +54,7 @@ header > h2 {
   border-top: 1px solid black;
 }
 
-.small-pages-scaling-container > .page:first-child {
+.small-pages-scaling-container .page:first-child {
   /* Separates left & right page and helps centering the cut */
   border-right: 1px solid #888888;
 }

--- a/src/serverMain/resources/viewQR/styles.css
+++ b/src/serverMain/resources/viewQR/styles.css
@@ -55,7 +55,7 @@ header > h2 {
 
 .small-pages-scaling-container > .page:first-child {
   /* Separates left & right page and helps centering the cut */
-  border-right: 1px solid #b3b3b3;
+  border-right: 1px solid #888888;
 }
 
 div.break {

--- a/src/serverMain/resources/viewQR/styles.css
+++ b/src/serverMain/resources/viewQR/styles.css
@@ -27,14 +27,35 @@ header > h2 {
   font-size: 32px;
 }
 
+.small-pages-container {
+  /* height must be 1mm less than A4 because of rounding errors that would otherwise leave empty pages */
+  height: 209mm;
+  width: 297mm;
+  overflow: hidden;
+  page-break-after: always;
+}
+
+.small-pages-scaling-container {
+  display: flex;
+  transform: scale(calc(210 / 297));
+  transform-origin: top left;
+}
+
 .page {
   height: 297mm;
-  width: 100%;
+  width: 210mm;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-evenly;
+  flex-grow: 0;
+  flex-shrink: 0;
   border-top: 1px solid black;
+}
+
+.small-pages-scaling-container > .page:first-child {
+  /* Separates left & right page and helps centering the cut */
+  border-right: 1px solid #2f2f2f;
 }
 
 div.break {


### PR DESCRIPTION
Edit:
Now with even more magic and cross-browser compatibility! Pages are always A4 but when the small pages config is set and the room has a seatCount, two Din A5 pages get rotated and put on a single A4 sheet. Also now supports two html templates, one for A4 and one for A5.

As you can see in the following image, this also allows printing all QR codes at once without worrying about separate orientations, paper sizes or other things. The relevant locations just rotate their pages.
<img height="450" alt="image" src="https://user-images.githubusercontent.com/33554869/97728816-4bacc400-1ad2-11eb-8db6-86000f59094d.png">

Old:
~Looks like this when printing in Chrome.~
<img height="280" alt="image" src="https://user-images.githubusercontent.com/33554869/97703296-af25fa00-1ab0-11eb-8dfb-39f1027e2eea.png">

~Firefox doesn't recognize the rotation automatically though, so the user has to select "landscape" before printing in this mode.~
When the config is 0 (default), nothing changes.