### PR TITLE
Escape semicolons and double qoutes in Excel CSV export

### DIFF
--- a/src/serverMain/kotlin/com/studo/campusqr/endpoints/ReportData.kt
+++ b/src/serverMain/kotlin/com/studo/campusqr/endpoints/ReportData.kt
@@ -209,7 +209,7 @@ internal suspend fun generateContactTracingReport(emails: List<String>, oldestDa
     impactedUsersEmailsCsvData = impactedUsersEmails.joinToString("\n"),
     impactedUsersEmailsCsvFileName = "${csvFilePrefix?.plus("-emails") ?: "emails"}.csv",
     reportedUserLocationsCsv = "sep=;\n" + reportedUserCheckIns.joinToString("\n") {
-      "${it.email};${it.date.toAustrianTime(yearAtBeginning = false)};${locationIdToLocationMap.getValue(it.locationId).name};${it.seat ?: "-"}"
+      "${it.email};${it.date.toAustrianTime(yearAtBeginning = false)};\"${locationIdToLocationMap.getValue(it.locationId).name.replace("\"", "\"\"")}\";${it.seat ?: "-"}"
     },
     reportedUserLocationsCsvFileName = "${csvFilePrefix?.plus("-checkins") ?: "checkins"}.csv",
     startDate = oldestDate.toAustrianTime("dd.MM.yyyy"),


### PR DESCRIPTION
CSV import in MS Excel breaks if location names contain semicolons (or double quotes). This fix applies Excel-syntax rules to the export and make the files Excel-compatible.

See issue #71 