### PR TITLE
Workaround for kotlinJs bug: hardcode kotlinJs webpack version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,9 @@ plugins {
   kotlin("jvm") version "1.5.10" apply false
 }
 
-// Workaround. Hardcode the webpack version: 4rc0 works fine while 5 doesn't. Remove when fixed.
+// Workaround. Hardcode the webpack version: 4rc0 works fine while 5 doesn't.
 // Bug report & details https://youtrack.jetbrains.com/issue/KT-48273
+// The fix was published in the experimental Kotlin version 1.5.30-382. TODO: Remove this workaround when 1.5.30 is stable
 rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java) {
   rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().versions.webpackDevServer.version = "4.0.0-rc.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,3 +12,9 @@ plugins {
   kotlin("js") version "1.5.10" apply false
   kotlin("jvm") version "1.5.10" apply false
 }
+
+// Workaround. Hardcode the webpack version: 4rc0 works fine while 5 doesn't. Remove when fixed.
+// Bug report & details https://youtrack.jetbrains.com/issue/KT-48273
+rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java) {
+  rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().versions.webpackDevServer.version = "4.0.0-rc.0"
+}


### PR DESCRIPTION
Hardcode webpack version to 4rc1 (working fine). There is a bug by which KotlinJS chooses the newest webpack version (5) without regard for semver.
Details: https://youtrack.jetbrains.com/issue/KT-48273
The fix for this was published in the experimental Kotlin version 1.5.30-382. Remove this workaround when 1.5.30 is stable.