### PR TITLE
User data state fix

### DIFF
--- a/moderatorFrontend/src/jsMain/kotlin/app/App.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/app/App.kt
@@ -43,7 +43,7 @@ val App = FcWithCoroutineScope<AppProps> { props, launch ->
   document.body?.style?.backgroundColor = "white"
 
   val fetchNewUserData = {
-    controller.fetchUserDataAndInit(null)
+    controller.fetchUserDataAndInit()
   }
 
   ThemeProvider {

--- a/moderatorFrontend/src/jsMain/kotlin/app/AppController.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/app/AppController.kt
@@ -149,13 +149,6 @@ data class AppController(
           getCurrentAppRoute = { currentAppRouteRef.current },
         )
 
-        val duplicatePaths = allUrls.groupBy { it.path }.filter { it.value.count() > 1 }.keys
-        if (duplicatePaths.isNotEmpty()) {
-          throw IllegalStateException(
-            "Duplicate path at ${duplicatePaths.first()} is not allowed by design. " +
-                "We need a 1:1 mapping of AppRoutes and paths"
-          )
-        }
         fetchUserDataAndInit { updatedUserData ->
           // Do not use currentAppRoute here, because it's not set yet.
           // currentAppRoute will be set in this function through pushAppRoute/handleHistoryChange.

--- a/moderatorFrontend/src/jsMain/kotlin/webcore/FcWithCoroutineScope.kt
+++ b/moderatorFrontend/src/jsMain/kotlin/webcore/FcWithCoroutineScope.kt
@@ -27,8 +27,9 @@ abstract class RComponentWithCoroutineScope<P : Props, S : State> : RComponent<P
  * Provide coroutine scope within functional components to allow cancellations.
  */
 @Suppress("FunctionName") fun <P : Props> FcWithCoroutineScope(
+  displayName: String? = null,
   block: ChildrenBuilder.(props: P, launch: Launch) -> Unit,
-) = FC<P> { props ->
+) = FC<P>(displayName ?: "No displayName defined") { props ->
   val scope = useMemo(*emptyArray<Any>()) { CoroutineScope(Dispatchers.Default + SupervisorJob()) }
 
   // TODO for future: @mh Use context parameters for this once released: https://github.com/Kotlin/KEEP/issues/367


### PR DESCRIPTION
State update is only finished when useEffect is called, so old userData was used in the block of `fetchUserDataAndInit`. This led to an infinite loading screen when logging in.